### PR TITLE
Add tracking persistence

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+-rc'
+    - '[0-9]+.[0-9]+.[0-9]+(-rc)?'
+    - '[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: viamrobotics/build-action@v1.4
+      with:
+        version: ${{ github.ref_name }}
+        ref: ${{ github.sha }}
+        key-id: ${{ secrets.viam_key_id }}
+        key-value: ${{ secrets.viam_key_value }}

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,6 @@
 module.tar.gz:
 	go build -a -o module main.go
 	tar -czf $@ module
+
+clean:
+	rm -rf module module.tar.gz

--- a/meta.json
+++ b/meta.json
@@ -13,5 +13,5 @@
     "build": "make module.tar.gz",
     "arch" : ["linux/amd64", "linux/arm64", "darwin/arm64"]
   },
-  "entrypoint": "pizza-tracker"
+  "entrypoint": "module"
 }

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://dl.viam.dev/module.schema.json",
   "module_id": "viam:pizza-tracker",
   "visibility": "public",
   "url": "https://github.com/viam-modules/pizza-tracking",

--- a/tracker/labels.go
+++ b/tracker/labels.go
@@ -6,6 +6,7 @@ package tracker
 
 import (
 	"fmt"
+	"image"
 	"strconv"
 	"strings"
 	"time"
@@ -27,36 +28,52 @@ func ReplaceLabel(tr *track, label string) *track {
 	return newTrack
 }
 
+// ReplaceBoundingBox replaces the detection with an almost identical detection (new bounding box)
+func ReplaceBoundingBox(tr *track, bb *image.Rectangle) *track {
+	det := objdet.NewDetection(*bb, tr.Det.Score(), tr.Det.Label())
+	newTrack := tr.clone()
+	newTrack.Det = det
+	return newTrack
+}
+
 // RenameFromMatches takes the output of the Hungarian matching algorithm and
 // gives the new detection the same label as the matching old detection.  Any new detections
 // found will be given a new name (and cleass counter will be updated)
 // Also return freshDets that are the fresh detections that were not matched with any detections in the previous frame.
-func (t *myTracker) RenameFromMatches(matches []int, matchinMtx [][]float64, oldDets, newDets []*track) ([]*track, []*track) {
+func (t *myTracker) RenameFromMatches(matches []int, matchinMtx [][]float64, oldDets, newDets []*track) ([]*track, []*track, []*track) {
 	// Fill up a map with the indices of newDetections we have
 	notUsed := make(map[int]struct{})
 	for i, _ := range newDets {
 		notUsed[i] = struct{}{}
 	}
 	// Go through valid matches and update name and track
+	updatedTracks := make([]*track, 0)
+	newlyStableTracks := make([]*track, 0)
 	for oldIdx, newIdx := range matches {
 		if newIdx != -1 {
 			if matchinMtx[oldIdx][newIdx] != 0 {
 				if newIdx >= 0 && newIdx < len(newDets) && oldIdx >= 0 && oldIdx < len(oldDets) {
-					newDets[newIdx] = ReplaceLabel(newDets[newIdx], oldDets[oldIdx].Det.Label())
-					t.UpdateTrack(newDets[newIdx])
+					// take the old track, clone it, and update their Bounding Box
+					// to the new track. Increment its persistence counter.
+					updatedTrack, newlyStable := t.UpdateTrack(newDets[newIdx], oldDets[oldIdx])
+					if newlyStable {
+						newlyStableTracks = append(newlyStableTracks, updatedTrack)
+					} else {
+						updatedTracks = append(updatedTracks, updatedTrack)
+					}
 					delete(notUsed, newIdx)
 				}
 			}
 		}
 	}
 	// Go through all NEW things and add them in (name them and start new track)
-	var freshDets []*track
+	freshTracks := make([]*track, 0)
 	for idx := range notUsed {
 		newDet := t.RenameFirstTime(newDets[idx])
 		newDets[idx] = newDet
-		freshDets = append(freshDets, newDet)
+		freshTracks = append(freshTracks, newDet)
 	}
-	return newDets, freshDets
+	return updatedTracks, newlyStableTracks, freshTracks
 }
 
 // RenameFirstTime should activate whenever a new object appears.
@@ -72,14 +89,28 @@ func (t *myTracker) RenameFirstTime(det *track) *track {
 	countLabel := baseLabel + "_" + strconv.Itoa(t.classCounter[baseLabel])
 	label := countLabel + "_" + GetTimestamp()
 	out := ReplaceLabel(det, label)
-	t.tracks[countLabel] = []*track{out} // Start new track with this one
+	// start a new track, but it will be tentative, and may be removed if lost
+	// before persistence counter reaches "stable"
+	t.tracks[countLabel] = []*track{out}
 	return out
 }
 
-func (t *myTracker) UpdateTrack(det *track) {
-	countLabel := strings.Join(strings.Split(det.Det.Label(), "_")[0:2], "_")
-	track, ok := t.tracks[countLabel]
+func getTrackingLabel(tr *track) string {
+	return strings.Join(strings.Split(tr.Det.Label(), "_")[0:2], "_")
+}
+
+// UpdateTrack changes the old bounding box to the new one, updates persistence,
+// and also returns if the track became newly stable
+func (t *myTracker) UpdateTrack(nextTrack, oldMatchedTrack *track) (*track, bool) {
+	wasStable := oldMatchedTrack.isStable()
+	newTrack := ReplaceBoundingBox(oldMatchedTrack, nextTrack.Det.BoundingBox())
+	newTrack.addPersistence()
+	countLabel := getTrackingLabel(newTrack)
+	trackSlice, ok := t.tracks[countLabel]
 	if ok {
-		t.tracks[countLabel] = append(track, det)
+		t.tracks[countLabel] = append(trackSlice, newTrack)
 	}
+	isNowStable := newTrack.isStable()
+	newlyStable := wasStable != isNowStable
+	return newTrack, newlyStable
 }

--- a/tracker/track.go
+++ b/tracker/track.go
@@ -1,0 +1,91 @@
+package tracker
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	objdet "go.viam.com/rdk/vision/objectdetection"
+)
+
+type track struct {
+	Det              objdet.Detection
+	persistenceLimit int
+	persistenceCount int
+	stable           bool
+}
+
+func newTrack(det objdet.Detection, lim int) *track {
+	return &track{det, lim, 0, false}
+}
+
+func newTracks(dets []objdet.Detection, lim int) []*track {
+	tracks := make([]*track, 0, len(dets))
+	for _, d := range dets {
+		tracks = append(tracks, newTrack(d, lim))
+	}
+	return tracks
+}
+
+func (tr *track) clone() *track {
+	return &track{
+		tr.Det,
+		tr.persistenceLimit,
+		tr.persistenceCount,
+		tr.stable,
+	}
+}
+
+func (tr *track) isStable() bool {
+	return tr.stable
+}
+
+func (tr *track) addPersistence() {
+	if tr.stable {
+		return
+	}
+	tr.persistenceCount += 1
+	if tr.persistenceCount >= tr.persistenceLimit {
+		tr.stable = true
+	}
+}
+
+func getStableDetections(tracks []*track) []objdet.Detection {
+	dets := make([]objdet.Detection, 0, len(tracks))
+	for _, tr := range tracks {
+		if tr.stable {
+			dets = append(dets, tr.Det)
+		}
+	}
+	return dets
+}
+
+func getAllDetections(tracks []*track) []objdet.Detection {
+	dets := make([]objdet.Detection, 0, len(tracks))
+	for _, tr := range tracks {
+		dets = append(dets, tr.Det)
+	}
+	return dets
+}
+
+type trackedObject struct {
+	FullLabel string
+	Label     string
+	Id        int
+	Time      string
+}
+
+func newTrackedObjectFromLabel(label string) (trackedObject, error) {
+	parts := strings.Split(label, "_")
+	id, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return trackedObject{}, errors.Wrapf(err, "unable to parse label %v", label)
+	}
+	return trackedObject{
+		FullLabel: label,
+		Label:     parts[0],
+		Id:        id,
+		Time:      strings.Join(parts[2:], "_"),
+	}, nil
+
+}

--- a/tracker/track.go
+++ b/tracker/track.go
@@ -8,6 +8,8 @@ import (
 	objdet "go.viam.com/rdk/vision/objectdetection"
 )
 
+// A track stores information about the bounding box as well as its persistence properties
+// across frames
 type track struct {
 	Det              objdet.Detection
 	persistenceLimit int
@@ -15,10 +17,12 @@ type track struct {
 	stable           bool
 }
 
+// newTrack turns a bounding box into a new track with a fresh persistence counter
 func newTrack(det objdet.Detection, lim int) *track {
 	return &track{det, lim, 0, false}
 }
 
+// newTracks turns a slice of bounding boxes into a track with a fresh persistence counter
 func newTracks(dets []objdet.Detection, lim int) []*track {
 	tracks := make([]*track, 0, len(dets))
 	for _, d := range dets {
@@ -27,6 +31,7 @@ func newTracks(dets []objdet.Detection, lim int) []*track {
 	return tracks
 }
 
+// clone will duplicate all the properties of the track
 func (tr *track) clone() *track {
 	return &track{
 		tr.Det,
@@ -36,10 +41,12 @@ func (tr *track) clone() *track {
 	}
 }
 
+// isStable returns that the track has persisted long enough to count as stable
 func (tr *track) isStable() bool {
 	return tr.stable
 }
 
+// addPersistence add to the persistence counter
 func (tr *track) addPersistence() {
 	if tr.stable {
 		return
@@ -50,6 +57,7 @@ func (tr *track) addPersistence() {
 	}
 }
 
+// return only the bounding boxes associated with stable tracks
 func getStableDetections(tracks []*track) []objdet.Detection {
 	dets := make([]objdet.Detection, 0, len(tracks))
 	for _, tr := range tracks {
@@ -60,14 +68,7 @@ func getStableDetections(tracks []*track) []objdet.Detection {
 	return dets
 }
 
-func getAllDetections(tracks []*track) []objdet.Detection {
-	dets := make([]objdet.Detection, 0, len(tracks))
-	for _, tr := range tracks {
-		dets = append(dets, tr.Det)
-	}
-	return dets
-}
-
+// trackedObject is the log info associated with the track that is stable
 type trackedObject struct {
 	FullLabel string
 	Label     string

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -69,7 +69,6 @@ type myTracker struct {
 	triggerContext    context.Context
 
 	activeBackgroundWorkers sync.WaitGroup
-	minTrackPersistence     int
 	lastDetections          []*track
 	currDetections          currentDetections
 	currImg                 atomic.Pointer[image.Image]
@@ -81,15 +80,16 @@ type myTracker struct {
 	coolDown    float64
 	properties  vision.Properties
 
-	cam           camera.Camera
-	camName       string
-	detector      vision.Service
-	frequency     float64
-	minConfidence float64
-	chosenLabels  map[string]float64
-	classCounter  map[string]int
-	tracks        map[string][]*track
-	timeStats     []time.Duration
+	cam                 camera.Camera
+	camName             string
+	detector            vision.Service
+	frequency           float64
+	minConfidence       float64
+	chosenLabels        map[string]float64
+	classCounter        map[string]int
+	tracks              map[string][]*track
+	timeStats           []time.Duration
+	minTrackPersistence int
 }
 
 func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (vision.Service, error) {
@@ -113,7 +113,7 @@ func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.C
 		return nil, err
 	}
 
-	//Defauly value for persistence
+	//Default value for persistence
 	if t.minTrackPersistence == 0 {
 		t.minTrackPersistence = DefaultMinTrackPersistence
 	}
@@ -163,7 +163,7 @@ func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.C
 	var lostDetections []*track
 	for idx, _ := range matches {
 		if matches[idx] == -1 {
-			// if lost detections are not stable, discard them
+			// if lost detection is not stable, discard it
 			if renamedOld[idx].isStable() {
 				lostDetections = append(lostDetections, renamedOld[idx])
 			}
@@ -320,11 +320,11 @@ type Config struct {
 	CameraName          string             `json:"camera_name"`
 	DetectorName        string             `json:"detector_name"`
 	ChosenLabels        map[string]float64 `json:"chosen_labels"`
-	MinTrackPersistence int                `json:"min_track_persistence"`
 	MaxFrequency        float64            `json:"max_frequency_hz"`
 	MinConfidence       *float64           `json:"min_confidence,omitempty"`
 	TriggerCoolDown     *float64           `json:"trigger_cool_down_s,omitempty"`
 	BufferSize          int                `json:"buffer_size,omitempty"`
+	MinTrackPersistence int                `json:"min_track_persistence"`
 }
 
 // Validate validates the config and returns implicit dependencies,


### PR DESCRIPTION
This PR does a few big things:

- Creates a struct called `track` that replaces the raw bounding box, in order to add information about persistence
- Drops un-matched tracks that get lost before the persistence period is complete
- only emits a new object classifications when something becomes newly stable
- new optional parameter called `min_track_persistence`